### PR TITLE
fix: Empty resources should return nil and error

### DIFF
--- a/primitives/covenant.go
+++ b/primitives/covenant.go
@@ -144,13 +144,16 @@ func RegisterFromCovenant(cov *Covenant) (*Register, error) {
 	if len(resourceB) > dns.MaxResourceSize {
 		return nil, errors.New("resource too large")
 	}
-	var resource *dns.Resource
-	if len(resourceB) > 0 {
-		resource = new(dns.Resource)
-		if err := resource.Decode(bytes.NewReader(resourceB)); err != nil {
-			return nil, err
-		}
+	if len(resourceB) == 0 {
+		return nil, errors.New("resource is empty")
 	}
+
+	var resource *dns.Resource
+	resource = new(dns.Resource)
+	if err := resource.Decode(bytes.NewReader(resourceB)); err != nil {
+		return nil, err
+	}
+
 	return &Register{
 		NameHash:         cov.Items[0],
 		Height:           binary.LittleEndian.Uint32(cov.Items[1]),
@@ -188,12 +191,13 @@ func UpdateFromCovenant(cov *Covenant) (*Update, error) {
 	if len(resourceB) > dns.MaxResourceSize {
 		return nil, errors.New("resource too large")
 	}
+	if len(resourceB) == 0 {
+		return nil, errors.New("resource is empty")
+	}
 	var resource *dns.Resource
-	if len(resourceB) > 0 {
-		resource = new(dns.Resource)
-		if err := resource.Decode(bytes.NewReader(resourceB)); err != nil {
-			return nil, err
-		}
+	resource = new(dns.Resource)
+	if err := resource.Decode(bytes.NewReader(resourceB)); err != nil {
+		return nil, err
 	}
 	return &Update{
 		NameHash: cov.Items[0],


### PR DESCRIPTION
Block 23731 has an empty string for Items[2], which caused Resource to be nil. Upstream code relied on the `Resource` object being non-nil, which led to an unxpected panic at runtime.

Because there is only one block where we found this behavior, I suspect it is a bug and the covenant should return `nil, err` if the resource cannot be decoded. But could a Convenant exist with a `nil` Resource? I don't have enough context loaded up about the spec to understand if this is the proper way to fix this bug.